### PR TITLE
📝 Add repository rename note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A fast CLI tool for synchronizing AI documentation rules across GitHub Copilot, 
 
 **Fast CLI built with Bun, compatible with Node.js and available via npx.**
 
+> **Note**: This project was formerly known as `ai-rule-forge`. The repository has been renamed to `ai-doc-sync` to better reflect its purpose of synchronizing AI documentation across multiple tools.
+
 ## Overview
 
 AI Doc Sync is a fast CLI tool built with Bun for synchronizing rules and knowledge across AI tools (GitHub Copilot, Cline, Cursor, etc.).


### PR DESCRIPTION
## Summary
This PR adds a note to the README documenting the repository rename from `ai-rule-forge` to `ai-doc-sync`.

## Changes
- Added a note explaining the project was formerly known as `ai-rule-forge`
- Clarified that the rename better reflects the tool's purpose of synchronizing AI documentation

## Why?
Users who knew the project by its previous name will understand the change and find the repository more easily.

🤖 Generated with [Claude Code](https://claude.ai/code)